### PR TITLE
feat: cloudflare_ruleset module

### DIFF
--- a/cloudflare_ruleset/README.md
+++ b/cloudflare_ruleset/README.md
@@ -1,0 +1,13 @@
+# cloudflare_ruleset
+
+Requirements:
+- `cloudflare` provider
+
+Required variables:
+- `account_id`
+- `kind`
+- `name`
+- `phase`
+- `status_code`
+- `target_url`
+- `zone_name`

--- a/cloudflare_ruleset/main.tf
+++ b/cloudflare_ruleset/main.tf
@@ -1,0 +1,26 @@
+resource "cloudflare_ruleset" "this" {
+  account_id = var.account_id
+  name       = var.name
+  kind       = var.kind
+  phase      = var.phase
+  zone_id = data.cloudflare_zone.this.id
+
+  rules {
+    action = "redirect"
+    action_parameters {
+      from_value {
+        status_code = var.status_code
+        target_url {
+          value = var.target_url
+        }
+        preserve_query_string = false
+      }
+    }
+    expression = "(http.host eq \"${var.name}\")"
+    enabled = true
+  }
+}
+
+data "cloudflare_zone" "this" {
+  name = var.zone_name
+}

--- a/cloudflare_ruleset/provider.tf
+++ b/cloudflare_ruleset/provider.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.1, < 2.0"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5"
+    }
+  }
+}

--- a/cloudflare_ruleset/variables.tf
+++ b/cloudflare_ruleset/variables.tf
@@ -1,0 +1,18 @@
+variable "kind" {
+  type = string
+}
+variable "name" {
+  type = string
+}
+variable "phase" {
+  type = string
+}
+variable "status_code" {
+  type = number
+}
+variable "target_url" {
+  type = string
+}
+variable "zone_name" {
+  type = string
+}


### PR DESCRIPTION
This module only supports a single type of rule, a permanent redirect of a host to another without preserving parameters.