### PR TITLE
feat(aws_eks): support secret encryption

### DIFF
--- a/aws_eks/eks.tf
+++ b/aws_eks/eks.tf
@@ -6,9 +6,10 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 21.0"
 
-  name               = var.cluster_name
-  kubernetes_version = var.cluster_version
-  enable_irsa        = true
+  name                      = var.cluster_name
+  kubernetes_version        = var.cluster_version
+  cluster_encryption_config = var.cluster_encryption_config
+  enable_irsa               = true
 
   # Disable default-enabled audit/api/authenticator logs
   enabled_log_types = []

--- a/aws_eks/variables.tf
+++ b/aws_eks/variables.tf
@@ -27,3 +27,13 @@ variable "tags" {
 variable "node_groups" {
   default = {}
 }
+variable "cluster_encryption_config" {
+  description = "Configuration for cluster encryption"
+  type = list(object({
+    provider = object({
+      key_arn = string
+    })
+    resources = list(string)
+  }))
+  default = []
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add support for EKS Secrets encryption at rest by exposing cluster_encryption_config and passing it to the upstream EKS module. Users can provide a KMS key ARN and resources to enable encryption; default remains disabled (no behavior change).

<sup>Written for commit 28973fbaaeca01b4496fd9b9876a4da5eed854de. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

