### PR TITLE
feat: add cluster encryption config support to aws_eks module

### DIFF
--- a/aws_eks/eks.tf
+++ b/aws_eks/eks.tf
@@ -6,10 +6,10 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 21.0"
 
-  name                      = var.cluster_name
-  kubernetes_version        = var.cluster_version
-  cluster_encryption_config = var.cluster_encryption_config
-  enable_irsa               = true
+  name               = var.cluster_name
+  kubernetes_version = var.cluster_version
+  encryption_config  = var.encryption_config
+  enable_irsa        = true
 
   # Disable default-enabled audit/api/authenticator logs
   enabled_log_types = []

--- a/aws_eks/variables.tf
+++ b/aws_eks/variables.tf
@@ -27,7 +27,7 @@ variable "tags" {
 variable "node_groups" {
   default = {}
 }
-variable "cluster_encryption_config" {
+variable "encryption_config" {
   description = "Configuration for cluster encryption"
   type = list(object({
     provider = object({


### PR DESCRIPTION
This PR corrects the parameter name for cluster encryption configuration in the aws_eks module, changing from cluster_encryption_config to encryption_config to match the upstream terraform-aws-modules/eks/aws module.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the aws_eks module to use encryption_config (instead of cluster_encryption_config) for EKS cluster secret encryption. Aligns with terraform-aws-modules/eks/aws and ensures KMS envelope encryption is configured correctly.

<sup>Written for commit fd17259a0793c49cdda84984d978dec8519d42b7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated infrastructure configuration parameter naming for improved consistency in EKS module inputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->