### PR TITLE
fix: remove eks encryption config

### DIFF
--- a/aws_eks/eks.tf
+++ b/aws_eks/eks.tf
@@ -8,7 +8,6 @@ module "eks" {
 
   name               = var.cluster_name
   kubernetes_version = var.cluster_version
-  encryption_config  = var.encryption_config
   enable_irsa        = true
 
   # Disable default-enabled audit/api/authenticator logs

--- a/aws_eks/variables.tf
+++ b/aws_eks/variables.tf
@@ -27,13 +27,3 @@ variable "tags" {
 variable "node_groups" {
   default = {}
 }
-variable "encryption_config" {
-  description = "Configuration for cluster encryption"
-  type = list(object({
-    provider = object({
-      key_arn = string
-    })
-    resources = list(string)
-  }))
-  default = []
-}


### PR DESCRIPTION
This is enabled on all clusters for some time. It's not necessary to set anymore.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed EKS encryption_config from the aws_eks module since cluster encryption is already enabled by default. This simplifies the module and removes a no-op setting.

- **Migration**
  - Remove encryption_config from any aws_eks module calls.
  - No changes needed on clusters; encryption remains enabled by default.

<sup>Written for commit 9db44c97f112465625e2d95b143d984c7206a6cb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed encryption configuration support from the EKS module. The `encryption_config` parameter is no longer available for use when provisioning EKS infrastructure. Users relying on this functionality will need to manage encryption configuration through alternative methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->