### PR TITLE
fix(aws_eks): correct encryption_config object

### DIFF
--- a/aws_eks/variables.tf
+++ b/aws_eks/variables.tf
@@ -28,12 +28,10 @@ variable "node_groups" {
   default = {}
 }
 variable "encryption_config" {
-  description = "Configuration for cluster encryption"
-  type = list(object({
-    provider = object({
-      key_arn = string
-    })
-    resources = list(string)
-  }))
-  default = []
+  description = "Configuration block with encryption configuration for the cluster"
+  type = object({
+    provider_key_arn = optional(string)
+    resources        = optional(list(string), ["secrets"])
+  })
+  default = {}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrected the aws_eks encryption_config variable to the expected object shape, removing the nested provider and defaulting resources to ["secrets"]. This fixes schema mismatches and simplifies configuration.

- **Bug Fixes**
  - Changed type from list(object({ provider.key_arn, resources })) to object with optional provider_key_arn and resources (default ["secrets"]).
  - Default updated from [] to {} to match the new object shape.

- **Migration**
  - If you set encryption_config, switch from a list to a single object: provider.key_arn → provider_key_arn; resources stays a list (defaults to ["secrets"] if omitted).

<sup>Written for commit 4275dd061873b608ea366d546b51b7af4528f3ee. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Updated encryption configuration variable structure from a list to a single object format with simplified defaults. Users must update their configuration accordingly when upgrading.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->