### PR TITLE
feat(add-iam-irsa-role): add iam irsa role

### DIFF
--- a/aws_eks/README.md
+++ b/aws_eks/README.md
@@ -9,6 +9,7 @@ Terraform module for deploying an Amazon EKS cluster with VPC, managed node grou
 - Configures essential EKS addons (CoreDNS, kube-proxy, VPC CNI, EBS CSI driver, Pod Identity Agent)
 - Sets up IRSA for EBS CSI driver and AWS Load Balancer Controller
 - Enables IRSA (IAM Roles for Service Accounts)
+- Optional IRSA role for external-dns (behind `enable_external_dns` flag)
 - Encrypts node root volumes with AWS KMS
 
 ## Usage
@@ -33,6 +34,8 @@ module "eks" {
       desired_size  = 1
     }
   }
+
+  enable_external_dns = true
 
   tags = {
     Environment = "production"
@@ -59,6 +62,7 @@ module "eks" {
 | public_subnets | List of public subnet CIDR blocks | `list(string)` | No | `["10.10.0.0/20", "10.10.16.0/20", "10.10.32.0/20"]` |
 | tags | Tags to apply to all resources | `any` | No | `[]` |
 | node_groups | Map of EKS managed node group configurations | `any` | No | `{}` |
+| enable_external_dns | Whether to create an IRSA role for external-dns | `bool` | No | `false` |
 
 ### Node Group Configuration
 
@@ -81,3 +85,9 @@ Each node group in the `node_groups` map supports the following attributes:
 | Name | Description |
 |------|-------------|
 | vpc | VPC module outputs (vpc_id, public_subnets, private_subnets, etc.) |
+| cluster_name | Name of the EKS cluster |
+| cluster_endpoint | Endpoint for the EKS cluster API server |
+| cluster_certificate_authority_data | Base64 encoded certificate data for the cluster |
+| oidc_provider_arn | ARN of the OIDC provider for IRSA |
+| oidc_provider | The OIDC provider URL (without protocol) |
+| external_dns_iam_role_arn | IAM role ARN for external-dns (null if disabled) |

--- a/aws_eks/iam.tf
+++ b/aws_eks/iam.tf
@@ -16,3 +16,23 @@ module "iam_aws_lb_controller" {
     }
   }
 }
+
+module "external_dns_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 6.0"
+
+  count = var.enable_external_dns ? 1 : 0
+
+  name = "${var.cluster_name}-external-dns"
+
+  attach_external_dns_policy = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:external-dns"]
+    }
+  }
+
+  tags = var.tags
+}

--- a/aws_eks/iam.tf
+++ b/aws_eks/iam.tf
@@ -27,10 +27,13 @@ module "external_dns_irsa" {
 
   attach_external_dns_policy = true
 
+  // We need StringLike to use * in the namespace_service_accounts
+  trust_condition_test = "StringLike"
+
   oidc_providers = {
     main = {
       provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["kube-system:external-dns"]
+      namespace_service_accounts = ["kube-system:*"]
     }
   }
 

--- a/aws_eks/output.tf
+++ b/aws_eks/output.tf
@@ -1,3 +1,27 @@
 output "vpc" {
   value = module.vpc
 }
+
+output "cluster_name" {
+  value = module.eks.cluster_name
+}
+
+output "cluster_endpoint" {
+  value = module.eks.cluster_endpoint
+}
+
+output "cluster_certificate_authority_data" {
+  value = module.eks.cluster_certificate_authority_data
+}
+
+output "oidc_provider_arn" {
+  value = module.eks.oidc_provider_arn
+}
+
+output "oidc_provider" {
+  value = module.eks.oidc_provider
+}
+
+output "external_dns_iam_role_arn" {
+  value = var.enable_external_dns ? module.external_dns_irsa[0].iam_role_arn : null
+}

--- a/aws_eks/variables.tf
+++ b/aws_eks/variables.tf
@@ -22,7 +22,8 @@ variable "public_subnets" {
   type    = list(string)
 }
 variable "tags" {
-  default = []
+  type    = map(string)
+  default = {}
 }
 variable "node_groups" {
   default = {}

--- a/aws_eks/variables.tf
+++ b/aws_eks/variables.tf
@@ -27,3 +27,8 @@ variable "tags" {
 variable "node_groups" {
   default = {}
 }
+variable "enable_external_dns" {
+  description = "Whether to create an IRSA role for external-dns"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional IRSA role for `external-dns` and exposes EKS/OIDC outputs to simplify integration and tooling. Enable it with `enable_external_dns`.

- **New Features**
  - Creates IAM role `${cluster_name}-external-dns` via `terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts` (v6) and attaches the ExternalDNS policy.
  - OIDC trust uses StringLike and allows `kube-system:*` service accounts.
  - Adds outputs (`cluster_name`, `cluster_endpoint`, `cluster_certificate_authority_data`, `oidc_provider_arn`, `oidc_provider`, `external_dns_iam_role_arn` (null when disabled)); converts `tags` to `map(string)` with `{}` default. README updated with usage and outputs.

<sup>Written for commit 86271c7148baa52e96a3d088a15a89e4c49be829. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional external-dns IRSA (IAM role) can be enabled via configuration
  * New cluster outputs: name, endpoint, certificate data, OIDC provider, and external-dns role ARN

* **Documentation**
  * README updated with the new configuration option and outputs

* **Chores**
  * `tags` input changed to a key/value map (default {})
<!-- end of auto-generated comment: release notes by coderabbit.ai -->