### PR TITLE
chore(update-sts-assume-role):update sts assume role

### DIFF
--- a/aws_eks/output.tf
+++ b/aws_eks/output.tf
@@ -23,5 +23,5 @@ output "oidc_provider" {
 }
 
 output "external_dns_iam_role_arn" {
-  value = var.enable_external_dns ? module.external_dns_irsa[0].iam_role_arn : null
+  value = var.enable_external_dns ? module.external_dns_irsa[0].arn : null
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the `external_dns_iam_role_arn` output to use the correct IRSA role ARN so STS assume-role works as expected with the latest module.
When `enable_external_dns` is true, we now return `module.external_dns_irsa[0].arn` instead of `module.external_dns_irsa[0].iam_role_arn`.

<sup>Written for commit 1d55464a0254953284dcd69df82d932e4a07f16c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the External DNS IAM role output to properly reference the underlying resource identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->