### PR TITLE
fix(aws_eks): set external_dns_hosted_zone_arns for external-dns IRSA

### DIFF
--- a/aws_eks/iam.tf
+++ b/aws_eks/iam.tf
@@ -38,5 +38,5 @@ module "external_dns_irsa" {
   }
 
   external_dns_hosted_zone_arns = ["*"]
-  tags = var.tags
+  tags                          = var.tags
 }

--- a/aws_eks/iam.tf
+++ b/aws_eks/iam.tf
@@ -37,5 +37,6 @@ module "external_dns_irsa" {
     }
   }
 
+  external_dns_hosted_zone_arns = ["*"]
   tags = var.tags
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `external_dns_hosted_zone_arns = ["*"]` for the external-dns IRSA so external-dns can manage Route 53 records across all hosted zones. Fixes IAM permission errors that blocked record creation and updates.

<sup>Written for commit 034c3e740ef9704aa34c1f5f5c634574e77aafb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded External DNS permissions to support all hosted zones in AWS EKS environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->