### PR TITLE
fix(aws_eks): fix external dns irsa hosted zone arns

### DIFF
--- a/aws_eks/iam.tf
+++ b/aws_eks/iam.tf
@@ -37,6 +37,6 @@ module "external_dns_irsa" {
     }
   }
 
-  external_dns_hosted_zone_arns = ["*"]
+  external_dns_hosted_zone_arns = var.external_dns_hosted_zone_arns
   tags                          = var.tags
 }

--- a/aws_eks/iam.tf
+++ b/aws_eks/iam.tf
@@ -38,5 +38,5 @@ module "external_dns_irsa" {
   }
 
   external_dns_hosted_zone_arns = ["*"]
-  tags = var.tags
+  tags                          = var.tags
 }

--- a/aws_eks/iam.tf
+++ b/aws_eks/iam.tf
@@ -37,5 +37,6 @@ module "external_dns_irsa" {
     }
   }
 
+  external_dns_hosted_zone_arns = ["*"]
   tags = var.tags
 }

--- a/aws_eks/variables.tf
+++ b/aws_eks/variables.tf
@@ -33,3 +33,9 @@ variable "enable_external_dns" {
   type        = bool
   default     = false
 }
+
+variable "external_dns_hosted_zone_arns" {
+  description = "Route53 hosted zone ARNs to allow External DNS to manage records"
+  type        = list(string)
+  default     = []
+}

--- a/aws_eks/variables.tf
+++ b/aws_eks/variables.tf
@@ -38,4 +38,9 @@ variable "external_dns_hosted_zone_arns" {
   description = "Route53 hosted zone ARNs to allow External DNS to manage records"
   type        = list(string)
   default     = []
+
+  validation {
+    condition     = !(var.enable_external_dns) || length(var.external_dns_hosted_zone_arns) > 0
+    error_message = "If enable_external_dns is true, you must provide at least one hosted zone ARN in external_dns_hosted_zone_arns."
+  }
 }

--- a/aws_eks/versions.tf
+++ b/aws_eks/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.1, < 2.0"
+  required_version = ">= 1.2, < 2.0"
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass Route53 hosted zone ARNs to ExternalDNS IRSA to scope permissions and remove wildcard access. Adds `external_dns_hosted_zone_arns` with validation and requires Terraform >= 1.2.

- **Bug Fixes**
  - Added `external_dns_hosted_zone_arns` (list(string), default []) with validation to require at least one ARN when `enable_external_dns` is true.
  - Passed the variable to `module.external_dns_irsa` in `iam.tf`, replacing `"*"`.

- **Migration**
  - Set `external_dns_hosted_zone_arns` to your Route53 hosted zone ARNs when enabling ExternalDNS.
  - Ensure Terraform version is `>= 1.2`.

<sup>Written for commit 939a4ac29972321fa43ea97f464230851833a675. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Route53 hosted zone access for External DNS. A new input variable enables administrators to specify which hosted zones are accessible to the External DNS integration, providing more granular access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->