### PR TITLE
chore(cloudflare_d1): widen provider version constraint to >=4.0,<6.0

### DIFF
--- a/cloudflare_d1/provider.tf
+++ b/cloudflare_d1/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 5"
+      version = ">= 4.0, < 6.0"
     }
   }
 }


### PR DESCRIPTION
Closes: #66 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated Cloudflare provider version compatibility to support versions 4.0 through 5.x, expanding compatibility range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widened the Terraform `cloudflare/cloudflare` provider constraint in the `cloudflare_d1` module to >=4.0,<6.0 to support both v4 and v5. This improves compatibility with existing deployments.

- **Migration**
  - If you use a provider lockfile or pinned version, run `terraform init -upgrade` to pick up the new range.

<sup>Written for commit 7788510db34885e8c3417da0fff437b40906694c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

