### PR TITLE
chore: update cloudflare_d1 terraform for v5

### DIFF
--- a/cloudflare_d1/main.tf
+++ b/cloudflare_d1/main.tf
@@ -2,4 +2,5 @@ resource "cloudflare_d1_database" "this" {
   account_id            = var.account_id
   name                  = var.name
   primary_location_hint = var.primary_location_hint
+  read_replication      = var.read_replication
 }

--- a/cloudflare_d1/variables.tf
+++ b/cloudflare_d1/variables.tf
@@ -8,3 +8,10 @@ variable "primary_location_hint" {
   type    = string
   default = null
 }
+variable "read_replication" {
+  description = "Read replication configuration. Set mode to \"auto\" or \"disabled\"."
+  type = object({
+    mode = string
+  })
+  default = null
+}

--- a/cloudflare_d1/variables.tf
+++ b/cloudflare_d1/variables.tf
@@ -13,5 +13,7 @@ variable "read_replication" {
   type = object({
     mode = string
   })
-  default = null
+  default = {
+    mode = "disabled"
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read replication support added for Cloudflare D1 databases via Terraform. An optional input lets you configure replication mode (defaults to "disabled"), and the setting is applied to database configuration to enable/manage read replicas and data distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds read replication support to the Cloudflare D1 Terraform module for v5 by introducing a `read_replication` input (mode: "auto" or "disabled"). This is passed through to the `cloudflare_d1_database` resource and defaults to `{ mode = "disabled" }` to preserve existing behavior.

<sup>Written for commit 485bf1583b6f5545a5ca7049ec41250db5240b95. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/terraform-modules/pull/69?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

