### PR TITLE
feat: add terraform R2 bucket module

### DIFF
--- a/cloudflare_r2/README.md
+++ b/cloudflare_r2/README.md
@@ -28,7 +28,6 @@ module "cloudflare_r2" {
 | name | Name of the R2 bucket | `string` | Yes | - |
 | location | Location hint for the bucket (e.g. `apac`, `eeur`, `enam`, `weur`, `wnam`) | `string` | No | `null` |
 | storage_class | Storage class for the bucket. One of `Standard` or `InfrequentAccess` | `string` | No | `"Standard"` |
-| jurisdiction | Jurisdiction for the bucket. One of `default`, `eu`, or `fedramp` | `string` | No | `"default"` |
 
 ## Outputs
 
@@ -36,5 +35,4 @@ module "cloudflare_r2" {
 |------|-------------|
 | name | The name of the R2 bucket |
 | location | The location of the R2 bucket |
-| jurisdiction | The jurisdiction of the R2 bucket |
 | storage_class | The storage class of the R2 bucket |

--- a/cloudflare_r2/README.md
+++ b/cloudflare_r2/README.md
@@ -28,6 +28,7 @@ module "cloudflare_r2" {
 | name | Name of the R2 bucket | `string` | Yes | - |
 | location | Location hint for the bucket (e.g. `apac`, `eeur`, `enam`, `weur`, `wnam`) | `string` | No | `null` |
 | storage_class | Storage class for the bucket. One of `Standard` or `InfrequentAccess` | `string` | No | `"Standard"` |
+| jurisdiction | Jurisdiction for the bucket. One of `default`, `eu`, or `fedramp` | `string` | No | `"default"` |
 
 ## Outputs
 
@@ -35,4 +36,5 @@ module "cloudflare_r2" {
 |------|-------------|
 | name | The name of the R2 bucket |
 | location | The location of the R2 bucket |
+| jurisdiction | The jurisdiction of the R2 bucket |
 | storage_class | The storage class of the R2 bucket |

--- a/cloudflare_r2/README.md
+++ b/cloudflare_r2/README.md
@@ -1,0 +1,40 @@
+# Cloudflare R2
+
+Terraform module for managing a Cloudflare R2 object storage bucket.
+
+## Usage
+
+```hcl
+module "cloudflare_r2" {
+  source = "git::https://github.com/blinklabs-io/terraform-modules.git?ref=cloudflare_r2/v0.1.0"
+
+  account_id = "your-cloudflare-account-id"
+  name       = "tosidrop-bucket"
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.1, < 2.0 |
+| cloudflare | ~> 5 |
+
+## Inputs
+
+| Name | Description | Type | Required | Default |
+|------|-------------|------|----------|---------|
+| account_id | Cloudflare account ID | `string` | Yes | - |
+| name | Name of the R2 bucket | `string` | Yes | - |
+| location | Location hint for the bucket (e.g. `apac`, `eeur`, `enam`, `weur`, `wnam`) | `string` | No | `null` |
+| storage_class | Storage class for the bucket. One of `Standard` or `InfrequentAccess` | `string` | No | `"Standard"` |
+| jurisdiction | Jurisdiction for the bucket. One of `default`, `eu`, or `fedramp` | `string` | No | `"default"` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| name | The name of the R2 bucket |
+| location | The location of the R2 bucket |
+| jurisdiction | The jurisdiction of the R2 bucket |
+| storage_class | The storage class of the R2 bucket |

--- a/cloudflare_r2/main.tf
+++ b/cloudflare_r2/main.tf
@@ -3,4 +3,5 @@ resource "cloudflare_r2_bucket" "this" {
   name          = var.name
   location      = var.location
   storage_class = var.storage_class
+  jurisdiction  = var.jurisdiction
 }

--- a/cloudflare_r2/main.tf
+++ b/cloudflare_r2/main.tf
@@ -1,0 +1,7 @@
+resource "cloudflare_r2_bucket" "this" {
+  account_id    = var.account_id
+  name          = var.name
+  location      = var.location
+  storage_class = var.storage_class
+  jurisdiction  = var.jurisdiction
+}

--- a/cloudflare_r2/main.tf
+++ b/cloudflare_r2/main.tf
@@ -3,5 +3,4 @@ resource "cloudflare_r2_bucket" "this" {
   name          = var.name
   location      = var.location
   storage_class = var.storage_class
-  jurisdiction  = var.jurisdiction
 }

--- a/cloudflare_r2/output.tf
+++ b/cloudflare_r2/output.tf
@@ -4,9 +4,6 @@ output "name" {
 output "location" {
   value = cloudflare_r2_bucket.this.location
 }
-output "jurisdiction" {
-  value = cloudflare_r2_bucket.this.jurisdiction
-}
 output "storage_class" {
   value = cloudflare_r2_bucket.this.storage_class
 }

--- a/cloudflare_r2/output.tf
+++ b/cloudflare_r2/output.tf
@@ -1,0 +1,12 @@
+output "name" {
+  value = cloudflare_r2_bucket.this.name
+}
+output "location" {
+  value = cloudflare_r2_bucket.this.location
+}
+output "jurisdiction" {
+  value = cloudflare_r2_bucket.this.jurisdiction
+}
+output "storage_class" {
+  value = cloudflare_r2_bucket.this.storage_class
+}

--- a/cloudflare_r2/output.tf
+++ b/cloudflare_r2/output.tf
@@ -4,6 +4,9 @@ output "name" {
 output "location" {
   value = cloudflare_r2_bucket.this.location
 }
+output "jurisdiction" {
+  value = cloudflare_r2_bucket.this.jurisdiction
+}
 output "storage_class" {
   value = cloudflare_r2_bucket.this.storage_class
 }

--- a/cloudflare_r2/provider.tf
+++ b/cloudflare_r2/provider.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.1, < 2.0"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5"
+    }
+  }
+}

--- a/cloudflare_r2/variables.tf
+++ b/cloudflare_r2/variables.tf
@@ -14,8 +14,3 @@ variable "storage_class" {
   type        = string
   default     = "Standard"
 }
-variable "jurisdiction" {
-  description = "Jurisdiction for the R2 bucket. One of `default`, `eu`, or `fedramp`."
-  type        = string
-  default     = "default"
-}

--- a/cloudflare_r2/variables.tf
+++ b/cloudflare_r2/variables.tf
@@ -1,0 +1,21 @@
+variable "account_id" {
+  type = string
+}
+variable "name" {
+  type = string
+}
+variable "location" {
+  description = "Location hint for the R2 bucket (e.g. `apac`, `eeur`, `enam`, `weur`, `wnam`)."
+  type        = string
+  default     = null
+}
+variable "storage_class" {
+  description = "Storage class for the R2 bucket. One of `Standard` or `InfrequentAccess`."
+  type        = string
+  default     = "Standard"
+}
+variable "jurisdiction" {
+  description = "Jurisdiction for the R2 bucket. One of `default`, `eu`, or `fedramp`."
+  type        = string
+  default     = "default"
+}

--- a/cloudflare_r2/variables.tf
+++ b/cloudflare_r2/variables.tf
@@ -14,3 +14,8 @@ variable "storage_class" {
   type        = string
   default     = "Standard"
 }
+variable "jurisdiction" {
+  description = "Jurisdiction for the R2 bucket. One of `default`, `eu`, or `fedramp`."
+  type        = string
+  default     = "default"
+}


### PR DESCRIPTION
Closes: #70 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Terraform module for creating a Cloudflare R2 bucket with configurable location, storage class, and jurisdiction.

- **New Features**
  - Inputs: account_id, name, location, storage_class, jurisdiction.
  - Outputs: name, location, storage_class, jurisdiction.
  - Requirements: Terraform >= 1.1 < 2.0, `cloudflare` provider `~> 5`.
  - README with a usage example.

<sup>Written for commit 686b3368ff75f47173dbac678d49e9397318805d. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/terraform-modules/pull/71?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Terraform module for provisioning Cloudflare R2 buckets with configurable parameters including account ID, bucket name, location, storage class, and jurisdiction settings. Bucket properties are exposed as outputs for downstream consumption.

* **Documentation**
  * Added comprehensive module documentation with usage examples, required version constraints, and detailed input/output specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->